### PR TITLE
给localStroage加上try以避免无缓存权限时崩溃

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -26,9 +26,9 @@ const utils = {
 
         get: (key) => {
             try {
-                localStorage.getItem(key)
+                return localStorage.getItem(key);
             } catch (e) {
-                return '{}'
+                return '{}';
             }
         }
     },

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -27,7 +27,9 @@ const utils = {
         get: (key) => {
             try {
                 localStorage.getItem(key)
-            } catch (e) {}
+            } catch (e) {
+                return '{}'
+            }
         }
     },
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -19,10 +19,16 @@ const utils = {
 
     storage: {
         set: (key, value) => {
-            localStorage.setItem(key, value);
+            try {
+                localStorage.setItem(key, value);
+            } catch (e) {}
         },
 
-        get: (key) => localStorage.getItem(key),
+        get: (key) => {
+            try {
+                localStorage.getItem(key)
+            } catch (e) {}
+        }
     },
 
     nameMap: {


### PR DESCRIPTION
新版本的Chrome默认阻止了iframe页面的本地缓存，这会导致整个APlayer崩溃，加上try可以避免。