### PR TITLE
fix: the time format for default lyrics

### DIFF
--- a/src/js/lrc.js
+++ b/src/js/lrc.js
@@ -48,10 +48,10 @@ class Lrc {
                 if (this.player.list.audios[index].lrc) {
                     this.parsed[index] = this.parse(this.player.list.audios[index].lrc);
                 } else {
-                    this.parsed[index] = [['00:00', 'Not available']];
+                    this.parsed[index] = [[0, 'Not available']];
                 }
             } else {
-                this.parsed[index] = [['00:00', 'Loading']];
+                this.parsed[index] = [[0, 'Loading']];
                 const xhr = new XMLHttpRequest();
                 xhr.onreadystatechange = () => {
                     if (index === this.player.list.index && xhr.readyState === 4) {
@@ -59,7 +59,7 @@ class Lrc {
                             this.parsed[index] = this.parse(xhr.responseText);
                         } else {
                             this.player.notice(`LRC file request fails: status ${xhr.status}`);
-                            this.parsed[index] = [['00:00', 'Not available']];
+                            this.parsed[index] = [[0, 'Not available']];
                         }
                         this.container.innerHTML = tplLrc({
                             lyrics: this.parsed[index],


### PR DESCRIPTION
Recently, I am using Vue3 to refactor the aplayer project, then discovered a small issue in the project.
The format of the parsed lyrics file is [[time, lrc], [time, lrc] ...], the time is a number rather than a string.
Of course, this is just a small issue.